### PR TITLE
Adding support for TCP port randomization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ repository = "https://github.com/quartiq/smoltcp-nal.git"
 heapless = ">=0.6.1"
 embedded-nal = "0.1"
 
+[dependencies.nanorand]
+version = "0.5.2"
+default-features = false
+features = ["wyrand"]
+
 [dependencies.smoltcp]
 version = "0.7"
 features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use smoltcp;
 
 use core::cell::RefCell;
 use heapless::{consts, Vec};
+use nanorand::{wyrand::WyRand, RNG};
 
 #[derive(Debug)]
 pub enum NetworkError {
@@ -22,8 +23,9 @@ where
 {
     network_interface: RefCell<smoltcp::iface::EthernetInterface<'b, DeviceT>>,
     sockets: RefCell<smoltcp::socket::SocketSet<'a>>,
-    next_port: RefCell<u16>,
+    used_ports: RefCell<Vec<u16, consts::U16>>,
     unused_handles: RefCell<Vec<smoltcp::socket::SocketHandle, consts::U16>>,
+    randomizer: RefCell<WyRand>,
 }
 
 impl<'a, 'b, DeviceT> NetworkStack<'a, 'b, DeviceT>
@@ -50,9 +52,18 @@ where
         NetworkStack {
             network_interface: RefCell::new(stack),
             sockets: RefCell::new(sockets),
-            next_port: RefCell::new(49152),
+            used_ports: RefCell::new(Vec::new()),
             unused_handles: RefCell::new(unused_handles),
+            randomizer: RefCell::new(WyRand::new()),
         }
+    }
+
+    /// Seed the TCP port randomizer.
+    ///
+    /// # Args
+    /// * `seed` - A seed of random data to use for randomizing local TCP port selection.
+    pub fn seed_random_port(&mut self, seed: &[u8]) {
+        self.randomizer.borrow_mut().reseed(seed)
     }
 
     /// Poll the network stack for potential updates.
@@ -75,13 +86,25 @@ where
 
     // Get an ephemeral TCP port number.
     fn get_ephemeral_port(&self) -> u16 {
-        // Get the next ephemeral port
-        let current_port = self.next_port.borrow().clone();
+        loop {
+            // Get the next ephemeral port by generating a random, valid TCP port continuously
+            // until an unused port is found.
+            let random_offset = {
+                let random_data = self.randomizer.borrow_mut().rand();
+                u16::from_be_bytes([random_data[0], random_data[1]])
+            };
 
-        let (next, wrap) = self.next_port.borrow().overflowing_add(1);
-        *self.next_port.borrow_mut() = if wrap { 49152 } else { next };
-
-        return current_port;
+            let port = 49152 + random_offset % (u16::MAX - 49152);
+            if self
+                .used_ports
+                .borrow()
+                .iter()
+                .find(|&x| *x == port)
+                .is_none()
+            {
+                return port;
+            }
+        }
     }
 }
 
@@ -127,6 +150,12 @@ where
                 let octets = addr.octets();
                 let address =
                     smoltcp::wire::Ipv4Address::new(octets[0], octets[1], octets[2], octets[3]);
+
+                // Note(unwrap): Only one port is allowed per socket, so this push should never
+                // fail.
+                let local_port = self.get_ephemeral_port();
+                self.used_ports.borrow_mut().push(local_port).unwrap();
+
                 internal_socket
                     .connect((address, remote.port()), self.get_ephemeral_port())
                     .map_err(|_| NetworkError::ConnectionFailure)?;
@@ -171,8 +200,16 @@ where
     fn close(&self, socket: smoltcp::socket::SocketHandle) -> Result<(), NetworkError> {
         let mut sockets = self.sockets.borrow_mut();
         let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(socket);
-        internal_socket.close();
 
+        // Remove the bound port form the used_ports buffer.
+        let local_port = internal_socket.local_endpoint().port;
+        let mut used_ports = self.used_ports.borrow_mut();
+        used_ports
+            .iter()
+            .position(|&port| port == local_port)
+            .and_then(|index| Some(used_ports.swap_remove(index)));
+
+        internal_socket.close();
         self.unused_handles.borrow_mut().push(socket).unwrap();
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ where
             network_interface: RefCell::new(stack),
             sockets: RefCell::new(sockets),
             used_ports: RefCell::new(Vec::new()),
-            randomizer: RefCell::new(WyRand::new()),
+            randomizer: RefCell::new(WyRand::new_seed(0)),
             dhcp_client: RefCell::new(dhcp),
             unused_handles: RefCell::new(unused_handles),
             name_servers: RefCell::new([None, None, None]),


### PR DESCRIPTION
This PR fixes #4 by using the WyRand algorithm to randomize local TCP support selection.

**TODO**:
- [x] Test randomization on hardware