### PR TITLE
Feature/dhcp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This document describes the changes to smoltcp-nal between releases.
 
 # Unreleased
 * Upgraded to 0.6.1 of heapless to address security vulnerability
+* Adding support for DHCP IP assignment and management.
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2021-02-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ embedded-nal = "0.1"
 
 [dependencies.smoltcp]
 version = "0.7"
-features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp"]
+features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp", "proto-dhcpv4"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ heapless = ">=0.6.1"
 embedded-nal = "0.1"
 
 [dependencies.smoltcp]
-version = "0.7"
+git = "https://github.com/ryan-summers/smoltcp"
+branch = "feature/dhcp-lease-updates"
 features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp", "proto-dhcpv4"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ heapless = ">=0.6.1"
 embedded-nal = "0.1"
 
 [dependencies.smoltcp]
-git = "https://github.com/ryan-summers/smoltcp"
-branch = "feature/dhcp-lease-updates"
+version = "0.7"
 features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp", "proto-dhcpv4"]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,8 @@ where
 
                     if let Some(route) = config.router {
                         // TODO: Determine if this unwrap is safe?
-                        interface.routes_mut()
+                        interface
+                            .routes_mut()
                             .add_default_ipv4_route(route)
                             .unwrap();
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub use embedded_nal;
 pub use smoltcp;
 
 use smoltcp::dhcp::Dhcpv4Client;
-use smoltcp::wire::{IpAddress, Ipv4Address, IpCidr};
+use smoltcp::wire::IpCidr;
 
 use core::cell::RefCell;
 use heapless::{consts, Vec};
@@ -116,19 +116,6 @@ where
                 Err(_) => {
                     // TODO: Handle this error somehow?
                 }
-            }
-
-            // Check if the DHCP lease has expired and remove configured values if it has.
-            if dhcp_client.lease_expired(now) {
-                interface.update_ip_addrs(|addrs| {
-                    addrs.iter_mut().next().map(|addr| {
-                        *addr = IpCidr::new(IpAddress::Ipv4(Ipv4Address::UNSPECIFIED), 0);
-                    });
-                });
-
-                interface.routes_mut()
-                    .add_default_ipv4_route(Ipv4Address::UNSPECIFIED)
-                    .unwrap();
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,9 +105,7 @@ where
 
                     if let Some(route) = config.router {
                         // TODO: Determine if this unwrap is safe?
-                        self.network_interface
-                            .borrow_mut()
-                            .routes_mut()
+                        interface.routes_mut()
                             .add_default_ipv4_route(route)
                             .unwrap();
                     }


### PR DESCRIPTION
This PR adds support for a DHCP client and fixes #6. When a DHCP client is used, the NAL will automatically manage IP address leases provided via the DHCP server.

This has been tested with stabilizer code and wireshark analysis indicates that IP addresses are being properly assigned.