### PR TITLE
DHCP / PHY reset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This document describes the changes to smoltcp-nal between releases.
 
 # Unreleased
+* Added a reset API to close all sockets and reset DHCP whenever a link is lost. Updated DHCP to
+  close sockets if local address changes.
 * Upgraded to 0.6.1 of heapless to address security vulnerability
 * Adding support for DHCP IP assignment and management.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ where
     /// Any handles provided to this function must not be used after constructing the network
     /// stack.
     ///
+    /// This implementation currently only supports IPv4.
+    ///
     /// # Args
     /// * `stack` - The ethernet interface to construct the network stack from.
     /// * `sockets` - The socket set to contain any socket state for the stack.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ where
             if let Some(ref mut socket) =
                 smoltcp::socket::TcpSocket::downcast(smoltcp::socket::SocketRef::new(&mut socket))
             {
-                socket.close();
+                socket.abort();
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,10 @@ where
                     smoltcp::wire::Ipv4Address::new(octets[0], octets[1], octets[2], octets[3]);
                 internal_socket
                     .connect((address, remote.port()), self.get_ephemeral_port())
-                    .map_err(|_| NetworkError::ConnectionFailure)?;
+                    .or_else(|_| {
+                        self.close(socket)?;
+                        Err(NetworkError::ConnectionFailure)
+                    })?;
                 Ok(socket)
             }
 


### PR DESCRIPTION
This PR updates the network stack to have a `reset()` function that can be called to shut down all active sockets and a means of allowing DHCP to close all active sockets if the IP address changes

This should make applications robust against changing IP addresses and/or ethernet plug cycling.

This fixes #8 

This also fixes #9 by updating the error handler to close the socket (which returns the handle for usage).