### PR TITLE
Fix mismatch between port in used_ports and actual port used by socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document describes the changes to smoltcp-nal between releases.
   close sockets if local address changes.
 * Upgraded to 0.6.1 of heapless to address security vulnerability
 * Adding support for DHCP IP assignment and management.
+* Fixed bug causing mismatch between ports in used_sockets and actual ports used by sockets
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2021-02-17

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ where
                 self.used_ports.borrow_mut().push(local_port).unwrap();
 
                 internal_socket
-                    .connect((address, remote.port()), self.get_ephemeral_port())
+                    .connect((address, remote.port()), local_port)
                     .or_else(|_| {
                         self.close(socket)?;
                         Err(NetworkError::ConnectionFailure)


### PR DESCRIPTION
In the connect function, a local port number is acquired from get_ephemeral_port function. That port number is then inserted into used_ports vector. In internal_socket.connect() instead of passing the same local port as argument, the function get_ephemeral_port is called again. The port used by socket does not match the port number stored in used_sockets. This results in panic when user tries to close the socket.