### PR TITLE
Fixing heapless dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming", "no-std"]
 repository = "https://github.com/quartiq/smoltcp-nal.git"
 
 [dependencies]
-heapless = ">=0.6.1"
+heapless = "0.6.1"
 embedded-nal = "0.1"
 
 [dependencies.nanorand]


### PR DESCRIPTION
Updating heapless to explicitly use 0.6.1 - code will not work with 0.7, as there are breaking changes.