### PR TITLE
Updating to v0.6 of the embedded-nal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document describes the changes to smoltcp-nal between releases.
 * Upgraded to 0.6.1 of heapless to address security vulnerability
 * Adding support for DHCP IP assignment and management.
 * Fixed bug causing mismatch between ports in used_sockets and actual ports used by sockets
+* Updating `embedded-nal` to 0.6
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2021-02-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ categories = ["network-programming", "no-std"]
 repository = "https://github.com/quartiq/smoltcp-nal.git"
 
 [dependencies]
-heapless = "0.6.1"
-embedded-nal = "0.1"
+heapless = "0.7"
+embedded-nal = "0.6"
 
 [dependencies.nanorand]
 version = "0.5.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@
 pub use embedded_nal;
 pub use smoltcp;
 
+use embedded_nal::TcpClientStack;
 use smoltcp::dhcp::Dhcpv4Client;
 use smoltcp::socket::AnySocket;
 use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address, Ipv4Cidr};
 
-use core::cell::RefCell;
-use heapless::{consts, Vec};
+use heapless::Vec;
 use nanorand::{wyrand::WyRand, RNG};
 
 // The start of TCP port dynamic range allocation.
@@ -29,13 +29,13 @@ pub struct NetworkStack<'a, 'b, DeviceT>
 where
     DeviceT: for<'c> smoltcp::phy::Device<'c>,
 {
-    network_interface: RefCell<smoltcp::iface::EthernetInterface<'b, DeviceT>>,
-    dhcp_client: RefCell<Option<Dhcpv4Client>>,
-    sockets: RefCell<smoltcp::socket::SocketSet<'a>>,
-    used_ports: RefCell<Vec<u16, consts::U16>>,
-    unused_handles: RefCell<Vec<smoltcp::socket::SocketHandle, consts::U16>>,
-    randomizer: RefCell<WyRand>,
-    name_servers: RefCell<[Option<smoltcp::wire::Ipv4Address>; 3]>,
+    network_interface: smoltcp::iface::EthernetInterface<'b, DeviceT>,
+    dhcp_client: Option<Dhcpv4Client>,
+    sockets: smoltcp::socket::SocketSet<'a>,
+    used_ports: Vec<u16, 16>,
+    unused_handles: Vec<smoltcp::socket::SocketHandle, 16>,
+    randomizer: WyRand,
+    name_servers: Vec<Ipv4Address, 3>,
 }
 
 impl<'a, 'b, DeviceT> NetworkStack<'a, 'b, DeviceT>
@@ -66,20 +66,20 @@ where
         handles: &[smoltcp::socket::SocketHandle],
         dhcp: Option<Dhcpv4Client>,
     ) -> Self {
-        let mut unused_handles: Vec<smoltcp::socket::SocketHandle, consts::U16> = Vec::new();
+        let mut unused_handles: Vec<smoltcp::socket::SocketHandle, 16> = Vec::new();
         for handle in handles.iter() {
             // Note: If the user supplies too many handles, we choose to silently drop them.
             unused_handles.push(*handle).ok();
         }
 
         NetworkStack {
-            network_interface: RefCell::new(stack),
-            sockets: RefCell::new(sockets),
-            used_ports: RefCell::new(Vec::new()),
-            randomizer: RefCell::new(WyRand::new_seed(0)),
-            dhcp_client: RefCell::new(dhcp),
-            unused_handles: RefCell::new(unused_handles),
-            name_servers: RefCell::new([None, None, None]),
+            network_interface: stack,
+            sockets,
+            used_ports: Vec::new(),
+            randomizer: WyRand::new_seed(0),
+            dhcp_client: dhcp,
+            unused_handles,
+            name_servers: Vec::new(),
         }
     }
 
@@ -88,44 +88,31 @@ where
     /// # Args
     /// * `seed` - A seed of random data to use for randomizing local TCP port selection.
     pub fn seed_random_port(&mut self, seed: &[u8]) {
-        self.randomizer.borrow_mut().reseed(seed)
+        self.randomizer.reseed(seed)
     }
 
     /// Poll the network stack for potential updates.
     ///
     /// # Returns
     /// A boolean indicating if the network stack updated in any way.
-    pub fn poll(&self, time: u32) -> Result<bool, smoltcp::Error> {
+    pub fn poll(&mut self, time: u32) -> Result<bool, smoltcp::Error> {
         let now = smoltcp::time::Instant::from_millis(time as i64);
-        let updated = match self
-            .network_interface
-            .borrow_mut()
-            .poll(&mut self.sockets.borrow_mut(), now)
-        {
-            Ok(updated) => updated,
-            err => return err,
-        };
+        let updated = self.network_interface.poll(&mut self.sockets, now)?;
 
         // Service the DHCP client.
-        if let Some(dhcp_client) = &mut *self.dhcp_client.borrow_mut() {
-            let mut interface = self.network_interface.borrow_mut();
-            let mut sockets = self.sockets.borrow_mut();
-            match dhcp_client.poll(&mut interface, &mut sockets, now) {
+        if let Some(ref mut dhcp_client) = self.dhcp_client {
+            match dhcp_client.poll(&mut self.network_interface, &mut self.sockets, now) {
                 Ok(Some(config)) => {
                     if let Some(cidr) = config.address {
                         if cidr.address().is_unicast() {
                             // Note(unwrap): This stack only supports IPv4 and the client must have
                             // provided an address.
                             if cidr.address().is_unspecified()
-                                || interface.ipv4_address().unwrap() != cidr.address()
+                                || self.network_interface.ipv4_address().unwrap() != cidr.address()
                             {
-                                // If our address has updated or is not specified, close all
-                                // sockets. Note that we have to ensure that the sockets we borrowed
-                                // earlier are now returned.
-                                drop(sockets);
                                 self.close_sockets();
 
-                                interface.update_ip_addrs(|addrs| {
+                                self.network_interface.update_ip_addrs(|addrs| {
                                     // Note(unwrap): This stack requires at least 1 Ipv4 Address.
                                     let addr = addrs
                                         .iter_mut()
@@ -143,12 +130,19 @@ where
                     }
 
                     // Store DNS server addresses for later read-back
-                    *self.name_servers.borrow_mut() = config.dns_servers;
+                    self.name_servers.clear();
+                    config
+                        .dns_servers
+                        .iter()
+                        .filter_map(|server| server.as_ref())
+                        .for_each(|server| self.name_servers.push(*server).unwrap());
 
                     if let Some(route) = config.router {
                         // Note: If the user did not provide enough route storage, we may not be
                         // able to store the gateway.
-                        interface.routes_mut().add_default_ipv4_route(route)?;
+                        self.network_interface
+                            .routes_mut()
+                            .add_default_ipv4_route(route)?;
                     }
                 }
                 Ok(None) => {}
@@ -160,9 +154,9 @@ where
     }
 
     /// Force-close all sockets.
-    pub fn close_sockets(&self) {
+    pub fn close_sockets(&mut self) {
         // Close all sockets.
-        for mut socket in self.sockets.borrow_mut().iter_mut() {
+        for mut socket in self.sockets.iter_mut() {
             // We only explicitly can close TCP sockets because we cannot access other socket types.
             if let Some(ref mut socket) =
                 smoltcp::socket::TcpSocket::downcast(smoltcp::socket::SocketRef::new(&mut socket))
@@ -175,15 +169,14 @@ where
     /// Handle a disconnection of the physical interface.
     pub fn handle_link_reset(&mut self) {
         // Reset the DHCP client.
-        if let Some(ref mut client) = *self.dhcp_client.borrow_mut() {
+        if let Some(ref mut client) = self.dhcp_client {
             client.reset(smoltcp::time::Instant::from_millis(-1));
         }
 
         // Close all of the sockets and de-configure the interface.
         self.close_sockets();
 
-        let mut interface = self.network_interface.borrow_mut();
-        interface.update_ip_addrs(|addrs| {
+        self.network_interface.update_ip_addrs(|addrs| {
             addrs.iter_mut().next().map(|addr| {
                 *addr = IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
             });
@@ -191,24 +184,18 @@ where
     }
 
     // Get an ephemeral TCP port number.
-    fn get_ephemeral_port(&self) -> u16 {
+    fn get_ephemeral_port(&mut self) -> u16 {
         loop {
             // Get the next ephemeral port by generating a random, valid TCP port continuously
             // until an unused port is found.
             let random_offset = {
-                let random_data = self.randomizer.borrow_mut().rand();
+                let random_data = self.randomizer.rand();
                 u16::from_be_bytes([random_data[0], random_data[1]])
             };
 
             let port = TCP_PORT_DYNAMIC_RANGE_START
                 + random_offset % (u16::MAX - TCP_PORT_DYNAMIC_RANGE_START);
-            if self
-                .used_ports
-                .borrow()
-                .iter()
-                .find(|&x| *x == port)
-                .is_none()
-            {
+            if self.used_ports.iter().find(|&x| *x == port).is_none() {
                 return port;
             }
         }
@@ -216,35 +203,28 @@ where
 
     fn is_ip_unspecified(&self) -> bool {
         // Note(unwrap): This stack only supports Ipv4.
-        self.network_interface
-            .borrow_mut()
-            .ipv4_addr()
-            .unwrap()
-            .is_unspecified()
+        self.network_interface.ipv4_addr().unwrap().is_unspecified()
     }
 }
 
-impl<'a, 'b, DeviceT> embedded_nal::TcpStack for NetworkStack<'a, 'b, DeviceT>
+impl<'a, 'b, DeviceT> TcpClientStack for NetworkStack<'a, 'b, DeviceT>
 where
     DeviceT: for<'c> smoltcp::phy::Device<'c>,
 {
     type Error = NetworkError;
     type TcpSocket = smoltcp::socket::SocketHandle;
 
-    fn open(
-        &self,
-        _mode: embedded_nal::Mode,
-    ) -> Result<smoltcp::socket::SocketHandle, NetworkError> {
+    fn socket(&mut self) -> Result<smoltcp::socket::SocketHandle, NetworkError> {
         // If we do not have a valid IP address yet, do not open the socket.
         if self.is_ip_unspecified() {
             return Err(NetworkError::NoIpAddress);
         }
 
-        match self.unused_handles.borrow_mut().pop() {
+        match self.unused_handles.pop() {
             Some(handle) => {
                 // Abort any active connections on the handle.
-                let mut sockets = self.sockets.borrow_mut();
-                let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(handle);
+                let internal_socket: &mut smoltcp::socket::TcpSocket =
+                    &mut *self.sockets.get(handle);
                 internal_socket.abort();
 
                 Ok(handle)
@@ -254,23 +234,23 @@ where
     }
 
     fn connect(
-        &self,
-        socket: smoltcp::socket::SocketHandle,
+        &mut self,
+        socket: &mut smoltcp::socket::SocketHandle,
         remote: embedded_nal::SocketAddr,
-    ) -> Result<smoltcp::socket::SocketHandle, NetworkError> {
+    ) -> embedded_nal::nb::Result<(), NetworkError> {
         // If there is no longer an IP address assigned to the interface, do not allow usage of the
         // socket.
         if self.is_ip_unspecified() {
-            self.close(socket)?;
-            return Err(NetworkError::NoIpAddress);
+            return Err(embedded_nal::nb::Error::Other(NetworkError::NoIpAddress));
         }
 
-        let mut sockets = self.sockets.borrow_mut();
-        let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(socket);
+        let local_port = self.get_ephemeral_port();
+
+        let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(*socket);
 
         // If we're already in the process of connecting, ignore the request silently.
         if internal_socket.is_open() {
-            return Ok(socket);
+            return Ok(());
         }
 
         match remote.ip() {
@@ -281,37 +261,35 @@ where
 
                 // Note(unwrap): Only one port is allowed per socket, so this push should never
                 // fail.
-                let local_port = self.get_ephemeral_port();
-                self.used_ports.borrow_mut().push(local_port).unwrap();
+                self.used_ports.push(local_port).unwrap();
 
                 internal_socket
                     .connect((address, remote.port()), local_port)
-                    .or_else(|_| {
-                        self.close(socket)?;
-                        Err(NetworkError::ConnectionFailure)
-                    })?;
-                Ok(socket)
+                    .map_err(|_| embedded_nal::nb::Error::Other(NetworkError::ConnectionFailure))?;
+                Ok(())
             }
 
             // We only support IPv4.
-            _ => Err(NetworkError::Unsupported),
+            _ => Err(embedded_nal::nb::Error::Other(NetworkError::Unsupported)),
         }
     }
 
-    fn is_connected(&self, socket: &smoltcp::socket::SocketHandle) -> Result<bool, NetworkError> {
+    fn is_connected(
+        &mut self,
+        socket: &smoltcp::socket::SocketHandle,
+    ) -> Result<bool, NetworkError> {
         // If there is no longer an IP address assigned to the interface, do not allow usage of the
         // socket.
         if self.is_ip_unspecified() {
             return Err(NetworkError::NoIpAddress);
         }
 
-        let mut sockets = self.sockets.borrow_mut();
-        let socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(*socket);
+        let socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(*socket);
         Ok(socket.may_send() && socket.may_recv())
     }
 
-    fn write(
-        &self,
+    fn send(
+        &mut self,
         socket: &mut smoltcp::socket::SocketHandle,
         buffer: &[u8],
     ) -> embedded_nal::nb::Result<usize, NetworkError> {
@@ -321,15 +299,14 @@ where
             return Err(embedded_nal::nb::Error::Other(NetworkError::NoIpAddress));
         }
 
-        let mut sockets = self.sockets.borrow_mut();
-        let socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(*socket);
+        let socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(*socket);
         socket
             .send_slice(buffer)
             .map_err(|_| embedded_nal::nb::Error::Other(NetworkError::WriteFailure))
     }
 
-    fn read(
-        &self,
+    fn receive(
+        &mut self,
         socket: &mut smoltcp::socket::SocketHandle,
         buffer: &mut [u8],
     ) -> embedded_nal::nb::Result<usize, NetworkError> {
@@ -339,29 +316,27 @@ where
             return Err(embedded_nal::nb::Error::Other(NetworkError::NoIpAddress));
         }
 
-        let mut sockets = self.sockets.borrow_mut();
-        let socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(*socket);
+        let socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(*socket);
         socket
             .recv_slice(buffer)
             .map_err(|_| embedded_nal::nb::Error::Other(NetworkError::ReadFailure))
     }
 
-    fn close(&self, socket: smoltcp::socket::SocketHandle) -> Result<(), NetworkError> {
-        let mut sockets = self.sockets.borrow_mut();
-        let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *sockets.get(socket);
+    fn close(&mut self, socket: smoltcp::socket::SocketHandle) -> Result<(), NetworkError> {
+        let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(socket);
 
         // Remove the bound port from the used_ports buffer.
         let local_port = internal_socket.local_endpoint().port;
-        let mut used_ports = self.used_ports.borrow_mut();
 
-        let index = used_ports
+        let index = self
+            .used_ports
             .iter()
             .position(|&port| port == local_port)
             .unwrap();
-        used_ports.swap_remove(index);
+        self.used_ports.swap_remove(index);
 
         internal_socket.close();
-        self.unused_handles.borrow_mut().push(socket).unwrap();
+        self.unused_handles.push(socket).unwrap();
         Ok(())
     }
 }


### PR DESCRIPTION
This PR resolves #11 by updating to embedded-nal v0.6 (the current release).

This PR also:
* Updates the repository to utilize const-generics
* Removes all usage of `RefCell`

**Testing**

This branch (along with the minimq update to the embedded-nal) were run on Stabilizer. It was confirmed that Stabilizer acquired an IP via DHCP and published MQTT telemetry as expected.