### PR TITLE
Correcting ephemeral port logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ features = ["wyrand"]
 
 [dependencies.smoltcp]
 version = "0.7"
-features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp", "proto-dhcpv4"]
+features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-tcp", "proto-dhcpv4", "socket-udp"]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ where
 
             let port = TCP_PORT_DYNAMIC_RANGE_START
                 + random_offset % (u16::MAX - TCP_PORT_DYNAMIC_RANGE_START);
-            if self.used_ports.contains(&port) {
+            if !self.used_ports.contains(&port) {
                 return port;
             }
         }
@@ -280,13 +280,13 @@ where
             return Err(embedded_nal::nb::Error::Other(NetworkError::NoIpAddress));
         }
 
-        let local_port = self.get_ephemeral_port();
+        {
+            let internal_socket: &mut smoltcp::socket::TcpSocket = &mut self.sockets.get(*socket);
 
-        let internal_socket: &mut smoltcp::socket::TcpSocket = &mut *self.sockets.get(*socket);
-
-        // If we're already in the process of connecting, ignore the request silently.
-        if internal_socket.is_open() {
-            return Ok(());
+            // If we're already in the process of connecting, ignore the request silently.
+            if internal_socket.is_open() {
+                return Ok(());
+            }
         }
 
         match remote.ip() {
@@ -295,10 +295,14 @@ where
                 let address =
                     smoltcp::wire::Ipv4Address::new(octets[0], octets[1], octets[2], octets[3]);
 
+                let local_port = self.get_ephemeral_port();
+
                 // Note(unwrap): Only one port is allowed per socket, so this insertion should never
                 // fail.
                 self.used_ports.insert(local_port).unwrap();
 
+                let internal_socket: &mut smoltcp::socket::TcpSocket =
+                    &mut *self.sockets.get(*socket);
                 internal_socket
                     .connect((address, remote.port()), local_port)
                     .map_err(|_| embedded_nal::nb::Error::Other(NetworkError::ConnectionFailure))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,7 @@ where
     }
 }
 
+#[derive(Copy, Debug, Clone)]
 pub struct UdpSocket {
     pub handle: smoltcp::socket::SocketHandle,
     destination: IpEndpoint,


### PR DESCRIPTION
This PR fixes #17 by inverting the ephemeral port logic so that it searches for an unused port (instead of a used port).

It also updates the code so that ephemeral ports are only calculated when needed for TCP - previously, they were being calculated for no reason.