### PR TITLE
Refactoring TCP ephemeral port assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This document describes the changes to smoltcp-nal between releases.
   close sockets if local address changes.
 * Upgraded to 0.6.1 of heapless to address security vulnerability
 * Adding support for DHCP IP assignment and management.
-* Fixed bug causing mismatch between ports in used_sockets and actual ports used by sockets
+* Fixed multiple bugs causing mismatch between ports in used_sockets and actual ports used by
+  sockets
 * Updating `embedded-nal` to 0.6
 * Added UDP client support
 


### PR DESCRIPTION
This PR refactors ephemeral TCP port number assignment such that a port is assigned at socket instantiation. It was discovered that smoltcp may close sockets internally (e.g. if a RST packet is received), which can cause the network stack to then allocate more and more ports for a single socket.

This fixes #25 

This keeps the management of the socket port number in this library layer, so we aren't dependent on another crates behavior to maintain the invariant required.