### PR TITLE
Shared: Add Network Stack Sharing Utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --all-features
 
   documentation:
     runs-on: ubuntu-latest
@@ -60,7 +61,8 @@ jobs:
       - name: Cargo Doc
         uses: actions-rs/cargo@v1
         with:
-          command: doc --all-features
+          command: doc
+          args: --all-features
 
   audit:
     runs-on: ubuntu-latest
@@ -93,18 +95,19 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --verbose
+          args: --verbose --all-features
 
       - name: Cargo Build
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --all-features
 
       - name: Cargo Build [Release]
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release --all-features
 
       - name: Cargo Build [Examples]
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Cargo Doc
         uses: actions-rs/cargo@v1
         with:
-          command: doc
+          command: doc --all-features
 
   audit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document describes the changes to smoltcp-nal between releases.
 * Updated `nanorand` to 0.6
 * Added support for the new `rand` requirement from `smoltcp`
 * Added polling via an `embedded_time::Clock`
+* Added `shared-cortex-m` feature for the new `shared` module
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2021-02-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ git = "https://github.com/smoltcp-rs/smoltcp"
 rev = "2dfc1598"
 features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp", "rand-custom-impl"]
 default-features = false
+
+[dependencies.shared-bus]
+version = "0.2.2" 
+optional = true
+
+[features]
+shared-cortex-m = ["shared-bus", "shared-bus/cortex-m"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ features = ["wyrand"]
 
 [dependencies.smoltcp]
 git = "https://github.com/smoltcp-rs/smoltcp"
-#branch = "master"
 rev = "2dfc1598"
 features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp", "rand-custom-impl"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ features = ["wyrand"]
 
 [dependencies.smoltcp]
 git = "https://github.com/smoltcp-rs/smoltcp"
-branch = "master"
+#branch = "master"
+rev = "2dfc1598"
 features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp", "rand-custom-impl"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ version = "0.2.2"
 optional = true
 
 [features]
-shared-cortex-m = ["shared-bus", "shared-bus/cortex-m"]
+shared-stack = ["shared-bus", "shared-bus/cortex-m"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use smoltcp::wire::{IpAddress, IpCidr, IpEndpoint, Ipv4Address, Ipv4Cidr};
 use heapless::Vec;
 use nanorand::wyrand::WyRand;
 
-#[cfg(feature = "shared-cortex-m")]
+#[cfg(feature = "shared-stack")]
 pub mod shared;
 
 // The start of TCP port dynamic range allocation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ use smoltcp::wire::{IpAddress, IpCidr, IpEndpoint, Ipv4Address, Ipv4Cidr};
 use heapless::Vec;
 use nanorand::wyrand::WyRand;
 
+#[cfg(feature = "shared-cortex-m")]
+pub mod shared;
+
 // The start of TCP port dynamic range allocation.
 const TCP_PORT_DYNAMIC_RANGE_START: u16 = 49152;
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,115 @@
+//! Network Stack Sharing Utilities
+//!
+//! # Design
+//! This module provides a mechanism for sharing a single network stack safely between drivers
+//that may or may not execute in multiple contexts. The design copies that of `shared-bus`.
+//!
+//! Specifically, the network stack is stored in a global static singleton and proxies to the
+//! underlying stack are handed out. The proxies provide an identical API for the
+//! `embedded_nal::TcpStack` stack trait, so they can be provided direclty to drivers that require
+//! a network stack.
+//!
+//! In order to ensure that pre-emption does not occur while accessing the same network stack from
+//! multiple interrupt contexts, the proxy uses an atomic boolean check - if the flag indicates the
+//! stack is in use, the proxy will generate a panic. The actual synchronization mechanism (mutex)
+//! leverages RTIC resource allocation. All devices that use the underlying network stack must be
+//! placed in a single RTIC resource, which will cause RTIC to prevent contention for the
+//! underlying network stack.
+use shared_bus::{AtomicCheckMutex, BusMutex};
+
+/// A manager for a shared network stack.
+pub struct NetworkManager<'a, 'b, DeviceT, Clock>
+where
+    DeviceT: for<'c> smoltcp::phy::Device<'c>,
+    Clock: embedded_time::Clock,
+    u32: From<Clock::T>,
+{
+    mutex: AtomicCheckMutex<crate::NetworkStack<'a, 'b, DeviceT, Clock>>,
+}
+
+/// A basic proxy that references a shared network stack.
+pub struct NetworkStackProxy<'a, S> {
+    mutex: &'a AtomicCheckMutex<S>,
+}
+
+impl<'a, S> NetworkStackProxy<'a, S> {
+    /// Using the proxy, access the underlying network stack directly.
+    ///
+    /// # Args
+    /// * `f` - A closure which will be provided the network stack as an argument.
+    ///
+    /// # Returns
+    /// Any value returned by the provided closure
+    pub fn lock<R, F: FnOnce(&mut S) -> R>(&mut self, f: F) -> R {
+        self.mutex.lock(|stack| f(stack))
+    }
+}
+
+// A simple forwarding macro taken from the `embedded-nal` to forward the embedded-nal API into the
+// proxy structure.
+macro_rules! forward {
+    ($func:ident($($v:ident: $IT:ty),*) -> $T:ty) => {
+        fn $func(&mut self, $($v: $IT),*) -> $T {
+            self.mutex.lock(|stack| stack.$func($($v),*))
+        }
+    }
+}
+
+// Implement a TCP stack for the proxy if the underlying network stack implements it.
+impl<'a, S> embedded_nal::TcpClientStack for NetworkStackProxy<'a, S>
+where
+    S: embedded_nal::TcpClientStack,
+{
+    type TcpSocket = S::TcpSocket;
+    type Error = S::Error;
+
+    forward! {socket() -> Result<S::TcpSocket, S::Error>}
+    forward! {connect(socket: &mut S::TcpSocket, remote: embedded_nal::SocketAddr) -> embedded_nal::nb::Result<(), S::Error>}
+    forward! {is_connected(socket: &S::TcpSocket) -> Result<bool, S::Error>}
+    forward! {send(socket: &mut S::TcpSocket, buffer: &[u8]) -> embedded_nal::nb::Result<usize, S::Error>}
+    forward! {receive(socket: &mut S::TcpSocket, buffer: &mut [u8]) -> embedded_nal::nb::Result<usize, S::Error>}
+    forward! {close(socket: S::TcpSocket) -> Result<(), S::Error>}
+}
+
+impl<'a, S> embedded_nal::UdpClientStack for NetworkStackProxy<'a, S>
+where
+    S: embedded_nal::UdpClientStack,
+{
+    type UdpSocket = S::UdpSocket;
+    type Error = S::Error;
+
+    forward! {socket() -> Result<S::UdpSocket, S::Error>}
+    forward! {connect(socket: &mut S::UdpSocket, remote: embedded_nal::SocketAddr) -> Result<(), S::Error>}
+
+    forward! {send(socket: &mut S::UdpSocket, buffer: &[u8]) -> embedded_nal::nb::Result<(), S::Error>}
+    forward! {receive(socket: &mut S::UdpSocket, buffer: &mut [u8]) -> embedded_nal::nb::Result<(usize, embedded_nal::SocketAddr), S::Error>}
+    forward! {close(socket: S::UdpSocket) -> Result<(), S::Error>}
+}
+
+impl<'a, 'b, DeviceT, Clock> NetworkManager<'a, 'b, DeviceT, Clock>
+where
+    DeviceT: for<'c> smoltcp::phy::Device<'c>,
+    Clock: embedded_time::Clock,
+    u32: From<Clock::T>,
+{
+    /// Construct a new manager for a shared network stack
+    ///
+    /// # Args
+    /// * `stack` - The network stack that is being shared.
+    pub fn new(stack: crate::NetworkStack<'a, 'b, DeviceT, Clock>) -> Self {
+        Self {
+            mutex: AtomicCheckMutex::create(stack),
+        }
+    }
+
+    /// Acquire a proxy to the shared network stack.
+    ///
+    /// # Returns
+    /// A proxy that can be used in place of the network stack. Note the requirements of
+    /// concurrency listed in the description of this file for usage.
+    pub fn acquire_stack(
+        &'_ self,
+    ) -> NetworkStackProxy<'_, crate::NetworkStack<'a, 'b, DeviceT, Clock>> {
+        NetworkStackProxy { mutex: &self.mutex }
+    }
+}


### PR DESCRIPTION
Shamelessly taken from your `stabilizer` firmware ;).

Motivation:
Since I couldn't find a way to trigger the poll function for `smoltcp`, when I use the `minimq` crate (no_std) without this or a similar implementation. And it took me quite some time to figure this out, I think it would be the best to add it as a feature.
