### PR TITLE
Updating documentation and smoltcp version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ This document describes the changes to smoltcp-nal between releases.
 * Updating `embedded-nal` to 0.6
 * Added UDP client support
 * Updated `nanorand` to 0.6
-* Added support for the new `rand` requirement from `smoltcp`
 * Added polling via an `embedded_time::Clock`
 * Added `shared-stack` feature for the new `shared` module
+* Updated to `smoltcp` version 0.8
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2021-02-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/quartiq/smoltcp-nal.git"
 [dependencies]
 heapless = "0.7"
 embedded-nal = "0.6"
-critical-section = "0.2.4"
 embedded-time = "0.12"
 
 [dependencies.nanorand]
@@ -21,13 +20,12 @@ default-features = false
 features = ["wyrand"]
 
 [dependencies.smoltcp]
-git = "https://github.com/smoltcp-rs/smoltcp"
-rev = "2dfc1598"
-features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp", "rand-custom-impl"]
+version = "0.8"
+features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp"]
 default-features = false
 
 [dependencies.shared-bus]
-version = "0.2.2" 
+version = "0.2.2"
 optional = true
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,18 @@
+//! A [embedded_nal]-compatible network stack for [smoltcp]
+//!
+//! # Usage
+//! To use this library, first instantiate the [smoltcp::iface::Interface] and add sockets to
+//! it. Once sockets have been added, pass the interface to [NetworkStack::new()].
+//!
+//! # Sharing the Stack
+//! If you have multiple users of the network stack, you can use the [shared::NetworkManager] by
+//! enabling the `shared-stack` feature. Note that this implementation does not employ any mutually
+//! exclusive access mechanism. For information on how to use this manager, refer to
+//! [shared_bus::AtomicCheckMutex]'s documentation.
+//!
+//! When sharing the stack, it is the users responsibility to ensure that access to the network
+//! stack is mutually exclusive. For example, this can be done when using RTIC by storing all of
+//! the resources that use the network stack in a single resource.
 #![no_std]
 
 use core::convert::TryFrom;
@@ -69,7 +84,7 @@ pub struct UdpSocket {
     destination: IpEndpoint,
 }
 
-///! Network abstraction layer for smoltcp.
+/// Network abstraction layer for smoltcp.
 pub struct NetworkStack<'a, DeviceT, Clock>
 where
     DeviceT: for<'x> smoltcp::phy::Device<'x>,
@@ -105,11 +120,10 @@ where
     ///
     /// # Args
     /// * `stack` - The ethernet interface to construct the network stack from.
-    /// * `sockets` - The socket set to contain any socket state for the stack.
     /// * `clock` - A clock to use for determining network time.
     ///
     /// # Returns
-    /// A embedded-nal-compatible network stack.
+    /// A [embedded_nal] compatible network stack.
     pub fn new(stack: smoltcp::iface::Interface<'a, DeviceT>, clock: Clock) -> Self {
         let mut unused_tcp_handles: Vec<SocketHandle, 16> = Vec::new();
         let mut unused_udp_handles: Vec<SocketHandle, 16> = Vec::new();

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -2,7 +2,7 @@
 //!
 //! # Design
 //! This module provides a mechanism for sharing a single network stack safely between drivers
-//that may or may not execute in multiple contexts. The design copies that of `shared-bus`.
+//! that may or may not execute in multiple contexts. The design copies that of `shared-bus`.
 //!
 //! Specifically, the network stack is stored in a global static singleton and proxies to the
 //! underlying stack are handed out. The proxies provide an identical API for the
@@ -18,13 +18,13 @@
 use shared_bus::{AtomicCheckMutex, BusMutex};
 
 /// A manager for a shared network stack.
-pub struct NetworkManager<'a, 'b, DeviceT, Clock>
+pub struct NetworkManager<'a, DeviceT, Clock>
 where
     DeviceT: for<'c> smoltcp::phy::Device<'c>,
     Clock: embedded_time::Clock,
     u32: From<Clock::T>,
 {
-    mutex: AtomicCheckMutex<crate::NetworkStack<'a, 'b, DeviceT, Clock>>,
+    mutex: AtomicCheckMutex<crate::NetworkStack<'a, DeviceT, Clock>>,
 }
 
 /// A basic proxy that references a shared network stack.
@@ -86,9 +86,9 @@ where
     forward! {close(socket: S::UdpSocket) -> Result<(), S::Error>}
 }
 
-impl<'a, 'b, DeviceT, Clock> NetworkManager<'a, 'b, DeviceT, Clock>
+impl<'a, DeviceT, Clock> NetworkManager<'a, DeviceT, Clock>
 where
-    DeviceT: for<'c> smoltcp::phy::Device<'c>,
+    DeviceT: for<'x> smoltcp::phy::Device<'x>,
     Clock: embedded_time::Clock,
     u32: From<Clock::T>,
 {
@@ -96,7 +96,7 @@ where
     ///
     /// # Args
     /// * `stack` - The network stack that is being shared.
-    pub fn new(stack: crate::NetworkStack<'a, 'b, DeviceT, Clock>) -> Self {
+    pub fn new(stack: crate::NetworkStack<'a, DeviceT, Clock>) -> Self {
         Self {
             mutex: AtomicCheckMutex::create(stack),
         }
@@ -109,7 +109,7 @@ where
     /// concurrency listed in the description of this file for usage.
     pub fn acquire_stack(
         &'_ self,
-    ) -> NetworkStackProxy<'_, crate::NetworkStack<'a, 'b, DeviceT, Clock>> {
+    ) -> NetworkStackProxy<'_, crate::NetworkStack<'a, DeviceT, Clock>> {
         NetworkStackProxy { mutex: &self.mutex }
     }
 }


### PR DESCRIPTION
This PR updates the `smoltcp-nal` to utilize the smoltcp 0.8 release.

This PR also beefs up some of the documentation.