### PR TITLE
Fixing loss of IP when DHCP not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This document describes the changes to smoltcp-nal between releases.
 
 # [Unreleased]
 
+## Fixed
+* Link reset when not using DHCP no longer removes IP address configuration
+
 # [0.2.0] - 2021-12-13
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,5 @@ This document describes the changes to smoltcp-nal between releases.
 * Initial library release and publish to crates.io
 
 [Unreleased]: https://github.com/quartiq/smoltcp-nal/compare/0.2.0...HEAD
-[0.2.0]: https://github.com/quartiq/smoltcp-nal/tag/0.2.0
-[0.1.0]: https://github.com/quartiq/smoltcp-nal/tag/0.1.0
+[0.2.0]: https://github.com/quartiq/smoltcp-nal/tree/0.2.0
+[0.1.0]: https://github.com/quartiq/smoltcp-nal/tree/0.1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,21 +300,21 @@ where
 
     /// Handle a disconnection of the physical interface.
     pub fn handle_link_reset(&mut self) {
+        // Close all of the sockets and de-configure the interface.
+        self.close_sockets();
+
         // Reset the DHCP client.
         if let Some(handle) = self.dhcp_handle {
             self.network_interface
                 .get_socket::<Dhcpv4Socket>(handle)
                 .reset();
-        }
 
-        // Close all of the sockets and de-configure the interface.
-        self.close_sockets();
-
-        self.network_interface.update_ip_addrs(|addrs| {
-            addrs.iter_mut().next().map(|addr| {
-                *addr = IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
+            self.network_interface.update_ip_addrs(|addrs| {
+                addrs.iter_mut().next().map(|addr| {
+                    *addr = IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0));
+                });
             });
-        });
+        }
     }
 
     /// Check if a port is currently in use.


### PR DESCRIPTION
This PR fixes #34 by only removing the configured IP address for the interface if a DHCP socket is in use.

This PR also fixes #33 by correcting CHANGELOG links.