### PR TITLE
Preparing for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This document describes the changes to smoltcp-nal between releases.
 
 # [Unreleased]
 ## Added
+## Fixed
+
+# [0.2.1]
+## Added
 * Public access to the smoltcp network interface
 
 ## Fixed
@@ -30,6 +34,7 @@ This document describes the changes to smoltcp-nal between releases.
 # Version [0.1.0] - 2021-02-17
 * Initial library release and publish to crates.io
 
-[Unreleased]: https://github.com/quartiq/smoltcp-nal/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/quartiq/smoltcp-nal/compare/0.2.1...HEAD
+[0.2.1]: https://github.com/quartiq/smoltcp-nal/tree/0.2.1
 [0.2.0]: https://github.com/quartiq/smoltcp-nal/tree/0.2.0
 [0.1.0]: https://github.com/quartiq/smoltcp-nal/tree/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoltcp-nal"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR prepares for a 0.2.1 release of the NAL.