### PR TITLE
Preparing for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 This document describes the changes to smoltcp-nal between releases.
 
+# [0.4.0] - 2023-07-21
+
+## Added
+* Updated to smoltcp 0.10
+
 # [0.3.0]
 
 ## Added
 * Implemented full UDP socket
-* [breaking] Updated to smoltcp 0.10
+* [breaking] Updated to smoltcp 0.9
 
 ## Changed
 * [breaking] embedded-nal updated to 0.7
@@ -39,7 +44,8 @@ This document describes the changes to smoltcp-nal between releases.
 # Version [0.1.0] - 2021-02-17
 * Initial library release and publish to crates.io
 
-[Unreleased]: https://github.com/quartiq/smoltcp-nal/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/quartiq/smoltcp-nal/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/quartiq/smoltcp-nal/tree/0.4.0
 [0.3.0]: https://github.com/quartiq/smoltcp-nal/tree/0.3.0
 [0.2.1]: https://github.com/quartiq/smoltcp-nal/tree/0.2.1
 [0.2.0]: https://github.com/quartiq/smoltcp-nal/tree/0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoltcp-nal"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Preps for a 0.4.0 release. I bumped the minor version because we're bumping smoltcp, so it _might_ be breaking on the users side.