### PR TITLE
Adding smoltcp-based DNS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document describes the changes to smoltcp-nal between releases.
 
+# [Unreleased]
+
+## Added
+* Added support for `embedded_nal::Dns` traits
+
 # [0.4.0] - 2023-07-21
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/quartiq/smoltcp-nal.git"
 heapless = "0.7"
 embedded-nal = "0.7"
 embedded-time = "0.12"
-log = {version = "0.4", default-features=false}
 
 [dependencies.nanorand]
 version = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/quartiq/smoltcp-nal.git"
 heapless = "0.7"
 embedded-nal = "0.7"
 embedded-time = "0.12"
+log = {version = "0.4", default-features=false}
 
 [dependencies.nanorand]
 version = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wyrand"]
 
 [dependencies.smoltcp]
 version = "0.10"
-features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dhcpv4", "socket-udp"]
+features = ["medium-ethernet", "proto-ipv6", "socket-tcp", "socket-dns", "socket-dhcpv4", "socket-udp"]
 default-features = false
 
 [dependencies.shared-bus]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ where
     sockets: smoltcp::iface::SocketSet<'a>,
     dhcp_handle: Option<SocketHandle>,
     dns_handle: Option<SocketHandle>,
-    dns_lookups: heapless::LinearMap<heapless::String<128>, smoltcp::socket::dns::QueryHandle, 2>,
+    dns_lookups: heapless::LinearMap<heapless::String<255>, smoltcp::socket::dns::QueryHandle, 2>,
     unused_tcp_handles: Vec<SocketHandle, 16>,
     unused_udp_handles: Vec<SocketHandle, 16>,
     clock: Clock,
@@ -697,7 +697,7 @@ where
         let handle = self.dns_handle.ok_or(NetworkError::Unsupported)?;
         let dns_socket: &mut smoltcp::socket::dns::Socket = self.sockets.get_mut(handle);
         let context = self.network_interface.context();
-        let key = heapless::String::from(hostname);
+        let key = heapless::String::try_from(hostname).map_err(|_| NetworkError::Unsupported)?;
 
         if let Some(handle) = self.dns_lookups.get(&key) {
             match dns_socket.get_query_result(*handle) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,6 @@ where
                 }
                 self.dns_lookups.clear();
 
-                log::info!("Got new DNS server from DHCP: \"{server:?}\"");
                 dns.update_servers(&[server]);
             }
         }
@@ -708,7 +707,6 @@ where
                     let smoltcp::wire::IpAddress::Ipv4(addr) = addr else {
                         panic!("Unexpected address return type");
                     };
-                    log::info!("DNS query for \"{hostname}\" finished: {addr:?}");
                     return Ok(embedded_nal::IpAddr::V4(addr.0.into()));
                 }
                 Err(smoltcp::socket::dns::GetQueryResultError::Pending) => {}
@@ -718,8 +716,7 @@ where
                 }
             }
         } else {
-            // TODO: Do we want to use other query types?
-            log::info!("Starting DNS query for \"{hostname}\"");
+            // Note: We only support A types because we are an Ipv4-only stack
             let dns_query = dns_socket
                 .start_query(context, hostname, smoltcp::wire::DnsQueryType::A)
                 .map_err(NetworkError::DnsStart)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,7 @@ where
                 }
                 self.dns_lookups.clear();
 
+                log::info!("Got new DNS server from DHCP: \"{server:?}\"");
                 dns.update_servers(&[server]);
             }
         }
@@ -707,6 +708,7 @@ where
                     let smoltcp::wire::IpAddress::Ipv4(addr) = addr else {
                         panic!("Unexpected address return type");
                     };
+                    log::info!("DNS query for \"{hostname}\" finished: {addr:?}");
                     return Ok(embedded_nal::IpAddr::V4(addr.0.into()));
                 }
                 Err(smoltcp::socket::dns::GetQueryResultError::Pending) => {}
@@ -717,6 +719,7 @@ where
             }
         } else {
             // TODO: Do we want to use other query types?
+            log::info!("Starting DNS query for \"{hostname}\"");
             let dns_query = dns_socket
                 .start_query(context, hostname, smoltcp::wire::DnsQueryType::A)
                 .map_err(NetworkError::DnsStart)?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -92,6 +92,15 @@ where
     forward! {send_to(socket: &mut S::UdpSocket, remote: embedded_nal::SocketAddr, buffer: &[u8]) -> embedded_nal::nb::Result<(), S::Error>}
     forward! {bind(socket: &mut S::UdpSocket, local_port: u16) -> Result<(), S::Error>}
 }
+impl<'a, S> embedded_nal::Dns for NetworkStackProxy<'a, S>
+where
+    S: embedded_nal::Dns,
+{
+    type Error = S::Error;
+
+    forward! {get_host_by_name(hostname: &str, addr_type: embedded_nal::AddrType) -> embedded_nal::nb::Result<embedded_nal::IpAddr, Self::Error>}
+    forward! {get_host_by_address(addr: embedded_nal::IpAddr) -> embedded_nal::nb::Result<embedded_nal::heapless::String<256>, Self::Error>}
+}
 
 impl<'a, Device, Clock> NetworkManager<'a, Device, Clock>
 where


### PR DESCRIPTION
This PR adds trait implementations for the embedded-nal `Dns` trait to allow libraries to resolve DNS queries at run time.

Current restrictions:
* Only 2 inflight queries allowed
* Each DNS query can only be up to 255 characters long

These limitations could go away if smoltcp was able to provide us info about in-flight queries, but I believe it does not cache them.