### PR TITLE
Fixing panic that comes from opening sockets before DHCP is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document describes the changes to smoltcp-nal between releases.
 
+# Unreleased
+
+## Fixed
+* Fixed an issue where attempting to open sockets before DHCP was completed wwould result in an
+internal panic.
+
 # [0.5.0] - 2024-04-22
 
 ## Changed


### PR DESCRIPTION
Addresses https://github.com/quartiq/stabilizer/issues/887 by updating the library to generate and propogate an error if the IP address is not yet assigned to the interface when a socket is opened and used.