### PR TITLE
 Update `heapless` to 0.8. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 
+* `heapless` updated to 0.8.
 * [breaking] `smoltcp` updated to 0.12.
 
 # [0.6.0](https://github.com/quartiq/smoltcp-nal/compare/v0.5.1...v0.6.0) - 2025-01-27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/quartiq/smoltcp-nal.git"
 rust-version = "1.77.0"
 
 [dependencies]
-heapless = "0.7"
+heapless = "0.8"
 embedded-nal = "0.9"
 embedded-time = "0.12"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,7 +708,7 @@ where
         let handle = self.dns_handle.ok_or(NetworkError::Unsupported)?;
         let dns_socket: &mut smoltcp::socket::dns::Socket = self.sockets.get_mut(handle);
         let context = self.network_interface.context();
-        let key = heapless::String::from(hostname);
+        let key = heapless::String::try_from(hostname).map_err(|_| NetworkError::Unsupported)?;
 
         if let Some(handle) = self.dns_lookups.get(&key) {
             match dns_socket.get_query_result(*handle) {


### PR DESCRIPTION
Needs a rebase after https://github.com/quartiq/smoltcp-nal/pull/54 is merged.